### PR TITLE
Lexer cleanup

### DIFF
--- a/test/LexTest.hs
+++ b/test/LexTest.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module LexTest (lexTests) where
 
 import qualified Data.Text as T
@@ -10,31 +11,31 @@ testLexInteger :: Test
 testLexInteger =
   TestCase $ assertEqual ("Lexing: " ++ show inputStr) expected (L.lex inputStr)
   where expected = [Tok.IntLiteral 123]
-        inputStr = (T.pack "123")
+        inputStr = "123"
 
 testLexIdentifierAlpha :: Test
 testLexIdentifierAlpha =
   TestCase $ assertEqual ("Lexing: " ++ show inputStr) expected (L.lex inputStr)
   where expected = [Tok.Identifier "foo"]
-        inputStr = (T.pack "foo")
+        inputStr = "foo"
 
 testLexIntKeyword :: Test
 testLexIntKeyword =
   TestCase $ assertEqual ("Lexing: " ++ show inputStr) expected (L.lex inputStr)
   where expected = [Tok.IntKeyword]
-        inputStr = (T.pack "int")
+        inputStr = "int"
 
 testLexIdentifierAlphaNum :: Test
 testLexIdentifierAlphaNum =
   TestCase $ assertEqual ("Lexing: " ++ show inputStr) expected (L.lex inputStr)
   where expected = [Tok.Identifier "myvar3"]
-        inputStr = (T.pack "myvar3")
+        inputStr = "myvar3"
 
 testLexIdentifierAlphaNumUnderscore :: Test
 testLexIdentifierAlphaNumUnderscore =
   TestCase $ assertEqual ("Lexing: " ++ show inputStr) expected (L.lex inputStr)
   where expected = [Tok.Identifier "_myvar3"]
-        inputStr = (T.pack "_myvar3")
+        inputStr = "_myvar3"
 
 lexTests :: Test
 lexTests = TestList [ testLexInteger


### PR DESCRIPTION
A few changes:

- `LexTest.hs` changed to use OverloadedStrings for better readability
- `lexRest` in `Lex.hs` no longer repeats the same code
- `lexRestAlphaNum` uses `Alternative` to avoid repeating case statements